### PR TITLE
fix: ignore merge commits

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -37,7 +37,8 @@ func isEmoji(s string) bool {
 }
 
 func determineConventionFromCommitMessage() (Provider, error) {
-	msg, err := exec.Command("git", "log", "-1", "--pretty=%B").Output()
+	// Get last commit message excluding merge commits
+	msg, err := exec.Command("git", "log", "-1", "--no-merges", "--pretty=%B").Output()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
Fixes an issue where merge commits were being used to determine the commit message convention. These commits should be excluded as they don't follow the usual commit message patterns.

### Changed
- Modified git log command to exclude merge commits when determining the convention by adding `--no-merges` flag [¹](a/provider.go#L41)

### Fixed
- Convention detection no longer considers merge commits which could lead to incorrect convention detection